### PR TITLE
PrimitiveModelの中身で、CharacterIdなどを使用する

### DIFF
--- a/Assets/Plugins/BlackSmith.Domain/BlackSmith.Domain.asmdef
+++ b/Assets/Plugins/BlackSmith.Domain/BlackSmith.Domain.asmdef
@@ -16,6 +16,11 @@
             "name": "org.nuget.r3",
             "expression": "",
             "define": ""
+        },
+        {
+            "name": "org.nuget.newtonsoft.json",
+            "expression": "",
+            "define": ""
         }
     ],
     "noEngineReferences": true

--- a/Assets/Plugins/BlackSmith.Domain/Domain/Character/Player/PlayerCommonEntity.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Domain/Character/Player/PlayerCommonEntity.cs
@@ -31,7 +31,7 @@ namespace BlackSmith.Domain.Character.Player
             Name = name ?? throw new ArgumentNullException("Not found PlayerName. (O94YoFRG)");
         }
 
-        internal PlayerCommonReconstractCommand GetReconstractCommand() => new(ID, Name, Level);
+        public PlayerCommonReconstractCommand GetReconstractCommand() => new(ID, Name, Level);
 
         /// <summary>
         /// 内部情報を文字列として表示する

--- a/Assets/Plugins/BlackSmith.Domain/Domain/Character/Player/PlayerFactory.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Domain/Character/Player/PlayerFactory.cs
@@ -33,7 +33,7 @@ namespace BlackSmith.Domain.Character.Player
 
             var command = new PlayerCommonReconstractCommand(id, name, level);
 
-            return new PlayerCommonEntity(command);
+            return Reconstruct(command);
         }
     }
 

--- a/Assets/Plugins/BlackSmith.Domain/Domain/Character/Player/PlayerFactory.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Domain/Character/Player/PlayerFactory.cs
@@ -38,7 +38,7 @@ namespace BlackSmith.Domain.Character.Player
     }
 
     /// <summary>プレイヤーの再構築を行う際に引数に指定して使う</summary>
-    internal record PlayerCommonReconstractCommand
+    public record PlayerCommonReconstractCommand
     {
         public CharacterID Id { get; }
         public PlayerName Name { get; }
@@ -49,6 +49,13 @@ namespace BlackSmith.Domain.Character.Player
             Id = id;
             Name = name;
             Level = level;
+        }
+
+        public PlayerCommonReconstractCommand(string id, string name, int exp)
+        {
+            Id = new CharacterID(id);
+            Name = new PlayerName(name);
+            Level = new PlayerLevel(new Experience(exp));
         }
     }
 }

--- a/Assets/Plugins/BlackSmith.Domain/Tests/BlackSmith.Domain.Tests.asmdef
+++ b/Assets/Plugins/BlackSmith.Domain/Tests/BlackSmith.Domain.Tests.asmdef
@@ -14,7 +14,8 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll"
+        "nunit.framework.dll",
+        "Newtonsoft.Json.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Assets/Plugins/BlackSmith.Domain/Tests/Usecase/AdjustPlayerCommonUsecaseTest.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Tests/Usecase/AdjustPlayerCommonUsecaseTest.cs
@@ -8,15 +8,13 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnityEngine;
-using static BlackSmith.Usecase.Character.AdjustPlayerCommonUsecase;
 
 #nullable enable
 
-namespace BlackSmith.Usecase.Character
+namespace BlackSmith.Usecase.Character.AdjustPlayerCommonUsecaseTest
 {
-    internal class AdjustPlayerCommonUsecaseTest
+    internal class CreateCharacterMethodTest
     {
-        #region CreateCharacter
         private static IEnumerable CreateCharacterTestCases()
         {
             var repository = new MockPlayerCommonEntityRepository();
@@ -57,9 +55,10 @@ namespace BlackSmith.Usecase.Character
                 }
             }
         }
-        #endregion
+    }
 
-        #region ReconstructCharacter
+    internal class ReconstructCharacterMethodTest
+    {
         private static IEnumerable ReconstructCharacterTestCases()
         {
             var repository = new MockPlayerCommonEntityRepository();
@@ -67,29 +66,25 @@ namespace BlackSmith.Usecase.Character
             var id = new CharacterID();
             var level = new PlayerLevel();
 
-            var model = new PlayerCommonReconstractPrimitiveModel(id.Value, name, level.CumulativeExp.Value);
+            var command = new PlayerCommonReconstractCommand(id.Value, name, level.CumulativeExp.Value);
 
-            yield return new TestCaseData(repository, model, null).SetCategory("正常系");
-
-            // modelのToCommandでコケる場合
-            var failModel = new PlayerCommonReconstractPrimitiveModel(id.Value, "", level.CumulativeExp.Value);
-            yield return new TestCaseData(repository, failModel, typeof(ArgumentException)).SetCategory("異常系");
+            yield return new TestCaseData(repository, command, null).SetCategory("正常系");
 
             // 既に同じIDのプレイヤーが存在する場合
             var entity = new PlayerCommonEntity(new PlayerCommonReconstractCommand(id, new PlayerName(name), level));
             var failRep = new MockPlayerCommonEntityRepository(new Dictionary<CharacterID, PlayerCommonEntity>() { { entity.ID, entity } });
-            yield return new TestCaseData(failRep, model, typeof(InvalidOperationException)).SetCategory("異常系");
+            yield return new TestCaseData(failRep, command, typeof(InvalidOperationException)).SetCategory("異常系");
         }
 
         [Test(Description = "ReconstructCharacterのテスト")]
         [TestCaseSource(nameof(ReconstructCharacterTestCases))]
-        public async Task ReconstructCharacterPasses(IPlayerCommonEntityRepository repository, PlayerCommonReconstractPrimitiveModel model, Type? exception)
+        public async Task ReconstructCharacterPasses(IPlayerCommonEntityRepository repository, PlayerCommonReconstractCommand command, Type? exception)
         {
             var usecase = new AdjustPlayerCommonUsecase(repository);
 
             if (exception is null)
             {
-                var character = await usecase.ReconstructPlayer(model);
+                var character = await usecase.ReconstructPlayer(command);
 
                 var entity = await repository.FindByID(character.ID);
 
@@ -102,7 +97,7 @@ namespace BlackSmith.Usecase.Character
             {
                 try
                 {
-                    await usecase.ReconstructPlayer(model);
+                    await usecase.ReconstructPlayer(command);
                 }
                 catch (Exception e)
                 {
@@ -110,21 +105,22 @@ namespace BlackSmith.Usecase.Character
                 }
             }
         }
-        #endregion
+    }
 
-        #region DeleteCharacter
+    internal class DeleteCharacterMethodTest
+    {
         private static IEnumerable DeleteCharacterTestCases()
         {
-            var repository = new MockPlayerCommonEntityRepository();
-
             var name = "TestPlayerName";
             var id = new CharacterID();
             var level = new PlayerLevel();
 
-            var model = new PlayerCommonReconstractPrimitiveModel(id.Value, name, level.CumulativeExp.Value);
+            var entity = new PlayerCommonEntity(new(id.Value, name, level.CumulativeExp.Value));
 
-            var usecase = new AdjustPlayerCommonUsecase(repository);
-            UniTask.Void(async () => await usecase.ReconstructPlayer(model));
+            var repository = new MockPlayerCommonEntityRepository(new Dictionary<CharacterID, PlayerCommonEntity>
+            {
+                { entity.ID, entity }
+            });
 
             yield return new TestCaseData(repository, id, null).SetCategory("正常系");
 
@@ -141,11 +137,14 @@ namespace BlackSmith.Usecase.Character
 
             if (exception is null)
             {
+
                 Assert.That(await repository.IsExist(id), Is.True);
 
                 await usecase.DeletePlayer(id);
 
                 Assert.That(await repository.IsExist(id), Is.False);
+
+                await repository.Register(new PlayerCommonEntity(new(id.Value, "TestPlayerName", 0))); // 消した後は追加して、元に戻す
             }
             else
             {
@@ -162,7 +161,56 @@ namespace BlackSmith.Usecase.Character
                 }
             }
         }
-        #endregion
+    }
+
+    internal class GetCharacterMethodTest
+    {
+        private static IEnumerable GetCharacterTestCases()
+        {
+            var repository = new MockPlayerCommonEntityRepository();
+
+            var name = "TestPlayerName";
+            var id = new CharacterID();
+            var level = new PlayerLevel();
+
+            var entity = new PlayerCommonEntity(new(id.Value, name, level.CumulativeExp.Value));
+
+            repository.Register(entity).Forget();
+
+            yield return new TestCaseData(repository, id, entity, null).SetCategory("正常系");
+
+            // 存在しないIDのプレイヤーを取得しようとした場合
+            var donotExistId = new CharacterID();
+            yield return new TestCaseData(repository, donotExistId, null, typeof(ArgumentException)).SetCategory("異常系");
+        }
+
+        [Test(Description = "GetPlayerDataのテスト")]
+        [TestCaseSource(nameof(GetCharacterTestCases))]
+        public async Task GetCharacterPasses(IPlayerCommonEntityRepository repository, CharacterID id, PlayerCommonEntity? target, Type? exception)
+        {
+            var usecase = new AdjustPlayerCommonUsecase(repository);
+
+            if (exception is null)
+            {
+                var character = await usecase.GetCharacter(id);
+
+                if (target is null)
+                    throw new InvalidOperationException("比較対象が引数で与えられていません");
+
+                Assert.That(character.Equals(target));
+            }
+            else
+            {
+                try
+                {
+                    await usecase.GetCharacter(id);
+                }
+                catch (Exception e)
+                {
+                    Assert.AreEqual(exception, e.GetType());
+                }
+            }
+        }
     }
 
     internal class MockPlayerCommonEntityRepository : IPlayerCommonEntityRepository

--- a/Assets/Plugins/BlackSmith.Domain/Tests/Usecase/AdjustPlayerCommonUsecaseTest.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Tests/Usecase/AdjustPlayerCommonUsecaseTest.cs
@@ -71,7 +71,7 @@ namespace BlackSmith.Usecase.Character.AdjustPlayerCommonUsecaseTest
             yield return new TestCaseData(repository, command, null).SetCategory("正常系");
 
             // 既に同じIDのプレイヤーが存在する場合
-            var entity = new PlayerCommonEntity(new PlayerCommonReconstractCommand(id, new PlayerName(name), level));
+            var entity = PlayerFactory.Reconstruct(new PlayerCommonReconstractCommand(id, new PlayerName(name), level));
             var failRep = new MockPlayerCommonEntityRepository(new Dictionary<CharacterID, PlayerCommonEntity>() { { entity.ID, entity } });
             yield return new TestCaseData(failRep, command, typeof(InvalidOperationException)).SetCategory("異常系");
         }
@@ -115,7 +115,7 @@ namespace BlackSmith.Usecase.Character.AdjustPlayerCommonUsecaseTest
             var id = new CharacterID();
             var level = new PlayerLevel();
 
-            var entity = new PlayerCommonEntity(new(id.Value, name, level.CumulativeExp.Value));
+            var entity = PlayerFactory.Reconstruct(new(id.Value, name, level.CumulativeExp.Value));
 
             var repository = new MockPlayerCommonEntityRepository(new Dictionary<CharacterID, PlayerCommonEntity>
             {
@@ -144,7 +144,7 @@ namespace BlackSmith.Usecase.Character.AdjustPlayerCommonUsecaseTest
 
                 Assert.That(await repository.IsExist(id), Is.False);
 
-                await repository.Register(new PlayerCommonEntity(new(id.Value, "TestPlayerName", 0))); // 消した後は追加して、元に戻す
+                await repository.Register(PlayerFactory.Reconstruct(new(id.Value, "TestPlayerName", 0))); // 消した後は追加して、元に戻す
             }
             else
             {
@@ -173,7 +173,7 @@ namespace BlackSmith.Usecase.Character.AdjustPlayerCommonUsecaseTest
             var id = new CharacterID();
             var level = new PlayerLevel();
 
-            var entity = new PlayerCommonEntity(new(id.Value, name, level.CumulativeExp.Value));
+            var entity = PlayerFactory.Reconstruct(new(id.Value, name, level.CumulativeExp.Value));
 
             repository.Register(entity).Forget();
 

--- a/Assets/Plugins/BlackSmith.Domain/Tests/Usecase/PlayerCommonEntityProvideUsecaseTest.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Tests/Usecase/PlayerCommonEntityProvideUsecaseTest.cs
@@ -1,0 +1,65 @@
+﻿using BlackSmith.Domain.Character;
+using BlackSmith.Domain.Character.Player;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System.Collections;
+using UnityEngine;
+
+namespace BlackSmith.Usecase.Character.PlayerCommonEntityProvideUsecaseTest
+{
+    internal class BuildCommonEntityMethodTest
+    {
+        private static IEnumerable BuildCommonEntityTestCases()
+        {
+            var id = new CharacterID();
+            var name = new PlayerName("TestPlayerName");
+            var level = new PlayerLevel(new Experience());
+
+            var command = new PlayerCommonReconstractCommand(id, name, level);
+
+            yield return new TestCaseData(command).SetCategory("正常系");
+        }
+
+        [Test(Description = "BuildCommonEntityのテスト")]
+        [TestCaseSource(nameof(BuildCommonEntityTestCases))]
+        public void BuildCommonEntityPasses(PlayerCommonReconstractCommand command)
+        {
+            var entity = PlayerCommonEntityProvidUsecase.BuildCommonEntity(command);
+
+            Assert.That(entity, Is.Not.Null); // エラーが出ずインスタンスが返ればOK
+        }
+
+        [Test(Description = "Commandのシリアライズ・デシリアライズのテスト")]
+        public void CommandSerializationTest()
+        {
+            var id = new CharacterID();
+            var idSerialized = JsonConvert.SerializeObject(id);
+            Debug.Log(idSerialized);
+            var idDeserialized = JsonConvert.DeserializeObject<CharacterID>(idSerialized);
+            Debug.Log(idSerialized + ", " + idDeserialized);
+
+            Assert.That(id, Is.EqualTo(idDeserialized));
+            
+
+            var name = new PlayerName("TestPlayerName");
+            var nameSerialized = JsonConvert.SerializeObject(name);
+            var nameDeserialized = JsonConvert.DeserializeObject<PlayerName>(nameSerialized);
+
+            Assert.That(name, Is.EqualTo(nameDeserialized));
+
+
+            var level = new PlayerLevel(new Experience());
+            var levelSerialized = JsonConvert.SerializeObject(level);
+            var levelDeserialized = JsonConvert.DeserializeObject<PlayerLevel>(levelSerialized);
+
+            Assert.That(level, Is.EqualTo(levelDeserialized));
+
+
+            var command = new PlayerCommonReconstractCommand(id, name, level);
+            var commandSerialized = JsonConvert.SerializeObject(command);
+            var commandDeseroalized = JsonConvert.DeserializeObject<PlayerCommonReconstractCommand>(commandSerialized);
+
+            Assert.That(command, Is.EqualTo(commandDeseroalized));
+        }
+    }
+}

--- a/Assets/Plugins/BlackSmith.Domain/Tests/Usecase/PlayerCommonEntityProvideUsecaseTest.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Tests/Usecase/PlayerCommonEntityProvideUsecaseTest.cs
@@ -1,9 +1,9 @@
 ﻿using BlackSmith.Domain.Character;
 using BlackSmith.Domain.Character.Player;
+using BlackSmith.Usecase.JsonConverters;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using System.Collections;
-using UnityEngine;
 
 namespace BlackSmith.Usecase.Character.PlayerCommonEntityProvideUsecaseTest
 {
@@ -33,31 +33,14 @@ namespace BlackSmith.Usecase.Character.PlayerCommonEntityProvideUsecaseTest
         public void CommandSerializationTest()
         {
             var id = new CharacterID();
-            var idSerialized = JsonConvert.SerializeObject(id);
-            Debug.Log(idSerialized);
-            var idDeserialized = JsonConvert.DeserializeObject<CharacterID>(idSerialized);
-            Debug.Log(idSerialized + ", " + idDeserialized);
-
-            Assert.That(id, Is.EqualTo(idDeserialized));
-            
-
             var name = new PlayerName("TestPlayerName");
-            var nameSerialized = JsonConvert.SerializeObject(name);
-            var nameDeserialized = JsonConvert.DeserializeObject<PlayerName>(nameSerialized);
-
-            Assert.That(name, Is.EqualTo(nameDeserialized));
-
-
             var level = new PlayerLevel(new Experience());
-            var levelSerialized = JsonConvert.SerializeObject(level);
-            var levelDeserialized = JsonConvert.DeserializeObject<PlayerLevel>(levelSerialized);
-
-            Assert.That(level, Is.EqualTo(levelDeserialized));
-
 
             var command = new PlayerCommonReconstractCommand(id, name, level);
-            var commandSerialized = JsonConvert.SerializeObject(command);
-            var commandDeseroalized = JsonConvert.DeserializeObject<PlayerCommonReconstractCommand>(commandSerialized);
+
+            var serialized = PlayerCommonEntityProvidUsecase.Serialize(command);
+
+            var commandDeseroalized = PlayerCommonEntityProvidUsecase.Deserialize(serialized);
 
             Assert.That(command, Is.EqualTo(commandDeseroalized));
         }

--- a/Assets/Plugins/BlackSmith.Domain/Tests/Usecase/PlayerCommonEntityProvideUsecaseTest.cs.meta
+++ b/Assets/Plugins/BlackSmith.Domain/Tests/Usecase/PlayerCommonEntityProvideUsecaseTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6d653eba6a743514d80255d4e2d7f882

--- a/Assets/Plugins/BlackSmith.Domain/Usecase/Character/AdjustPlayerCommonUsecase.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/Character/AdjustPlayerCommonUsecase.cs
@@ -55,12 +55,11 @@ namespace BlackSmith.Usecase.Character
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        /// <exception cref="Exception"></exception>
-        /// <exception cref="ArgumentException"></exception>
-        public async UniTask<PlayerCommonEntity> GetPlayerData(CharacterID id)
+        /// <exception cref="ArgumentException">指定したIdのキャラクターが存在しない場合</exception>
+        public async UniTask<PlayerCommonEntity> GetCharacter(CharacterID id)
         {
-            if (!(await repository.IsExist(id)))
-                throw new Exception($"指定したidのキャラクターは存在しません {id}");
+            if (!await repository.IsExist(id))
+                throw new ArgumentException($"指定したidのキャラクターは存在しません {id}");
 
             var entity = (await repository.FindByID(id)) ?? throw new ArgumentException($"指定したidのキャラクターは存在しません {id}");
 

--- a/Assets/Plugins/BlackSmith.Domain/Usecase/Character/PlayerCommonEntityProvidUsecase.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/Character/PlayerCommonEntityProvidUsecase.cs
@@ -1,4 +1,6 @@
 ﻿using BlackSmith.Domain.Character.Player;
+using BlackSmith.Usecase.JsonConverters;
+using Newtonsoft.Json;
 
 namespace BlackSmith.Usecase.Character
 {
@@ -15,6 +17,24 @@ namespace BlackSmith.Usecase.Character
         public static PlayerCommonEntity BuildCommonEntity(PlayerCommonReconstractCommand command)
         {
             return PlayerFactory.Reconstruct(command);
+        }
+
+        public static string Serialize(PlayerCommonReconstractCommand command)
+        {
+            return JsonConvert.SerializeObject(command);
+        }
+
+        public static PlayerCommonReconstractCommand Deserialize(string json)
+        {
+            var commandJsonConverters = new JsonConverter[]
+{
+                new PlayerCommonReconstractCommandJsonConverter(),
+                new CharacterIDJsonConverter(),
+                new PlayerNameJsonConverter(),
+                new PlayerLevelJsonConverter(),
+                new ExperienceJsonConverter()
+            };
+            return JsonConvert.DeserializeObject<PlayerCommonReconstractCommand>(json, commandJsonConverters);
         }
     }
 }

--- a/Assets/Plugins/BlackSmith.Domain/Usecase/Character/PlayerCommonEntityProvidUsecase.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/Character/PlayerCommonEntityProvidUsecase.cs
@@ -1,8 +1,4 @@
-﻿using BlackSmith.Domain.Character;
-using BlackSmith.Domain.Character.Player;
-using BlackSmith.Usecase.Interface;
-using Cysharp.Threading.Tasks;
-using System;
+﻿using BlackSmith.Domain.Character.Player;
 
 namespace BlackSmith.Usecase.Character
 {
@@ -11,21 +7,14 @@ namespace BlackSmith.Usecase.Character
     /// </summary>
     public class PlayerCommonEntityProvidUsecase
     {
-        private readonly IPlayerCommonEntityRepository repository;
-
-        public PlayerCommonEntityProvidUsecase(IPlayerCommonEntityRepository playerRepository)
+        /// <summary>
+        /// Commandを用いて再構築を行う, リポジトリへの登録は行わない
+        /// </summary>
+        /// <param name="command"></param>
+        /// <returns></returns>
+        public static PlayerCommonEntity BuildCommonEntity(PlayerCommonReconstractCommand command)
         {
-            repository = playerRepository;
-        }
-
-        public async UniTask<PlayerCommonEntity> GetPlayerData(CharacterID id)
-        {
-            if (!(await repository.IsExist(id)))
-                throw new Exception($"指定したidのキャラクターは存在しません {id}");
-
-            var entity = (await repository.FindByID(id)) ?? throw new ArgumentException($"指定したidのキャラクターは存在しません {id}");
-
-            return entity;
+            return PlayerFactory.Reconstruct(command);
         }
     }
 }

--- a/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter.meta
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b8e5aeb9cd548d45b563066c0d113ca
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/CharacterIDJsonConverter.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/CharacterIDJsonConverter.cs
@@ -1,0 +1,36 @@
+﻿using BlackSmith.Domain.Character;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+
+#nullable enable
+
+namespace BlackSmith
+{
+    public class CharacterIDJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(CharacterID);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            if (!CanConvert(objectType))
+                throw new JsonSerializationException($"JsonConverter {nameof(CharacterIDJsonConverter)} cannot convert {objectType}.");
+
+            JObject jo = JObject.Load(reader);
+
+            string? value = jo["Value"]?.Value<string>() ?? throw new JsonSerializationException("Json param key \"Value\" is not found.");
+
+            var id = new CharacterID(value);
+
+            return id;
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/CharacterIDJsonConverter.cs.meta
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/CharacterIDJsonConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1ce9f15f3ddb7f647b3024280214c680

--- a/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/PlayerCommonReconstractCommandJsonConverter.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/PlayerCommonReconstractCommandJsonConverter.cs
@@ -1,0 +1,37 @@
+﻿using BlackSmith.Domain.Character;
+using BlackSmith.Domain.Character.Player;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+
+#nullable enable
+
+namespace BlackSmith.Usecase.JsonConverters
+{
+    public class PlayerCommonReconstractCommandJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(PlayerCommonReconstractCommand);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            if (!CanConvert(objectType))
+                throw new JsonSerializationException($"JsonConverter {nameof(PlayerCommonReconstractCommandJsonConverter)} cannot convert {objectType}.");
+
+            var jo = JObject.Load(reader);
+
+            var id = jo["Id"]?.ToObject<CharacterID>(serializer) ?? throw new JsonSerializationException("Json param key \"ID\" is not found.");
+            var name = jo["Name"]?.ToObject<PlayerName>(serializer) ?? throw new JsonSerializationException("Json param key \"Name\" is not found.");
+            var level = jo["Level"]?.ToObject<PlayerLevel>(serializer) ?? throw new JsonSerializationException("Json param key \"Level\" is not found.");
+
+            return new PlayerCommonReconstractCommand(id, name, level);
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/PlayerCommonReconstractCommandJsonConverter.cs.meta
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/PlayerCommonReconstractCommandJsonConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bb130dbd6dfc2c146a7bc37a79c47a11

--- a/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/PlayerLevelJsonConverter.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/PlayerLevelJsonConverter.cs
@@ -1,0 +1,86 @@
+﻿using BlackSmith.Domain.Character;
+using BlackSmith.Domain.Character.Player;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Diagnostics;
+
+#nullable enable
+
+namespace BlackSmith.Usecase.JsonConverters
+{
+    public class CharacterLevelJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(CharacterLevel);
+        }
+
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            if (!CanConvert(objectType))
+                throw new JsonSerializationException($"JsonConverter {nameof(CharacterLevelJsonConverter)} cannot convert {objectType}.");
+
+            var jo = JObject.Load(reader);
+
+            var value = jo["Value"]?.Value<int>() ?? throw new JsonSerializationException("Json param key \"Value\" is not found.");
+
+            return new CharacterLevel(value);
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class ExperienceJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Experience);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            if (!CanConvert(objectType))
+                throw new JsonSerializationException($"JsonConverter {nameof(ExperienceJsonConverter)} cannot convert {objectType}.");
+
+            var jo = JObject.Load(reader);
+
+            var value = jo["Value"]?.Value<int>() ?? throw new JsonSerializationException("Json param key \"Value\" is not found.");
+
+            return new Experience(value);
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class PlayerLevelJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(PlayerLevel);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            if (!CanConvert(objectType))
+                throw new JsonSerializationException($"JsonConverter {nameof(PlayerLevelJsonConverter)} cannot convert {objectType}.");
+
+            var jo = JObject.Load(reader);
+
+            var exp = jo["CumulativeExp"]?.ToObject<Experience>(serializer) ?? throw new JsonSerializationException("Json param key \"Value\" is not found.");
+
+            return new PlayerLevel(exp);
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/PlayerLevelJsonConverter.cs.meta
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/PlayerLevelJsonConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dd8e5f6b7e1341c438515323876b3bec

--- a/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/PlayerNameJsonConverter.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/PlayerNameJsonConverter.cs
@@ -1,4 +1,4 @@
-﻿using BlackSmith.Domain.Character;
+﻿using BlackSmith.Domain.Character.Player;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -7,25 +7,23 @@ using System;
 
 namespace BlackSmith.Usecase.JsonConverters
 {
-    internal class CharacterIDJsonConverter : JsonConverter
+    public class PlayerNameJsonConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
-            return objectType == typeof(CharacterID);
+           return objectType == typeof(PlayerName);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             if (!CanConvert(objectType))
-                throw new JsonSerializationException($"JsonConverter {nameof(CharacterIDJsonConverter)} cannot convert {objectType}.");
+                throw new JsonSerializationException($"JsonConverter {nameof(PlayerNameJsonConverter)} cannot convert {objectType}.");
 
             var jo = JObject.Load(reader);
 
             var value = jo["Value"]?.Value<string>() ?? throw new JsonSerializationException("Json param key \"Value\" is not found.");
 
-            var id = new CharacterID(value);
-
-            return id;
+            return new PlayerName(value);
         }
 
         public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)

--- a/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/PlayerNameJsonConverter.cs.meta
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/JsonConverter/PlayerNameJsonConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63b00185f957ae54487737f7c8a780f1

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,6 +3,7 @@
     "com.cysharp.unitask": "2.5.5",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.test-framework": "2.0.1-exp.2",
+    "org.nuget.newtonsoft.json": "13.0.3",
     "org.nuget.r3": "1.2.8",
     "com.unity.modules.jsonserialize": "1.0.0"
   },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -52,6 +52,13 @@
       },
       "url": "https://unitynuget-registry.azurewebsites.net"
     },
+    "org.nuget.newtonsoft.json": {
+      "version": "13.0.3",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://unitynuget-registry.azurewebsites.net"
+    },
     "org.nuget.r3": {
       "version": "1.2.8",
       "depth": 0,


### PR DESCRIPTION
# 残タスク
- [ ] `PlsyerCommonEntity`の再構築を行うメソッドのテスト追加
- [ ] `Command`のシリアライズ・デシリアライズテストの追加

# 発生している問題
## `CharacterID`などをそのままの形でシリアライズ・デシリアライズできない
- 原因
  - 外部公開のパラメータとコンストラクタが直接一致していないため
    - `CharacterID`は`BasicID`を継承している
      - `BasicID`はコンストラクタで`id`を要求し、外部に`Value`を公開している
      ```C#
      public abstract record BasicID
      {
          protected abstract string Prefix { get; }
          public string Value => Prefix + guid;
          ...
          internal BasicID(string id) { ... }
          ...
      }
      ```
      - そのため、`CharacterID`をシリアライズした際のJsonは以下のようになる
      ```JSON
      {
        "Value":"Character-c982d7b1-d3bd-4702-b4bd-21121c78ea4c"
      }
      ```
- 解決方法
  - シリアライズの際に`Value`ではなく`id`でJsonを作成するようにする
  - デシリアライズの際にコンストラクタの`id`に`Value`を使用するようにする
  1. `ToJson`, `FromJson`のようなメソッドを追加する
  2. `JsonConverter`を作成する
     -  `JsonConvert.DeserializeObject<CharacterID>(idSerialized, new CharacterIDJsonConverter());`オブジェクトのデシリアライズ時に`Converter`を設定する
- 結論
  - `JsonConverter`を作成する方法が素直そうなので、その方針で行く
  - ただし、`JsonConverter`を直接`public class`として外部公開するのではなく、ユースケースを作成する
---
close #119 
close #120 