### PR TITLE
AdjustCommonCharacterEntityUsecaseにNPC生成対応と型安全性向上を実装

### DIFF
--- a/Assets/Plugins/BlackSmith.Domain/Usecase/Character/AdjustCommonCharacterEntityUsecase.cs
+++ b/Assets/Plugins/BlackSmith.Domain/Usecase/Character/AdjustCommonCharacterEntityUsecase.cs
@@ -22,15 +22,30 @@ namespace BlackSmith.Usecase.Character
 
         // 外部にpublicで公開されているのは、各パラメータの値のみであるため、Entityを返却しても問題ない
         /// <summary>
-        /// キャラクターデータの作成を行う
+        /// キャラクターデータの作成を行う（プレイヤー用）
         /// </summary>
-        /// <param name="name">作成するキャラクターの名前</param>
+        /// <param name="characterName">作成するキャラクターの名前</param>
         /// <returns>作成したキャラクターエンティティ</returns>
-        public async UniTask<CommonCharacterEntity> CreateCharacter(string characterName)
+        public async UniTask<CommonCharacterEntity> CreateCharacter(CharacterName characterName)
         {
-            var name = new CharacterName(characterName);
+            var entity = CommonCharacterFactory.Create(characterName);
 
-            var entity = CommonCharacterFactory.Create(name);
+            await repository.Register(entity);
+
+            return entity;
+        }
+
+        /// <summary>
+        /// キャラクターデータの作成を行う（NPC用）
+        /// </summary>
+        /// <param name="characterName">作成するキャラクターの名前</param>
+        /// <param name="level">作成するキャラクターのレベル</param>
+        /// <returns>作成したキャラクターエンティティ</returns>
+        public async UniTask<CommonCharacterEntity> CreateCharacter(CharacterName characterName, CharacterLevel level)
+        {
+            var id = new CharacterID();
+            var command = new CommonCharacterReconstructCommand(id, characterName, level);
+            var entity = CommonCharacterFactory.Reconstruct(command);
 
             await repository.Register(entity);
 

--- a/Assets/Plugins/BlackSmith.Domain/docs/domains/Character.md
+++ b/Assets/Plugins/BlackSmith.Domain/docs/domains/Character.md
@@ -451,7 +451,13 @@ var repository = // IPlayerCommonEntityRepositoryの実装
 var usecase = new AdjustPlayerCommonEntityUsecase(repository);
 
 // プレイヤー作成（初期レベル1、経験値 0で作成）
-var player = await usecase.CreateCharacter("冒険者");
+var playerName = new CharacterName("冒険者");
+var player = await usecase.CreateCharacter(playerName);
+
+// NPC作成（名前とレベルを指定）
+var npcName = new CharacterName("商人");
+var npcLevel = new CharacterLevel(new Experience(5000)); // レベル15相当
+var npc = await usecase.CreateCharacter(npcName, npcLevel);
 ```
 
 #### 2. プレイヤー再構築

--- a/Assets/Plugins/BlackSmith.Domain/docs/systems/LevelingSystem.md
+++ b/Assets/Plugins/BlackSmith.Domain/docs/systems/LevelingSystem.md
@@ -170,7 +170,8 @@ internal class SkillExpCalculator
 // プレイヤーエンティティ管理
 public class AdjustPlayerCommonEntityUsecase
 {
-    internal async UniTask<PlayerCommonEntity> CreateCharacter(string playerName);     // 新規作成
+    internal async UniTask<PlayerCommonEntity> CreateCharacter(CharacterName characterName);           // プレイヤー新規作成
+    internal async UniTask<PlayerCommonEntity> CreateCharacter(CharacterName characterName, CharacterLevel level); // NPC新規作成
     internal async UniTask<PlayerCommonEntity> ReconstructPlayer(PlayerCommonReconstructCommand command); // 復元
     internal async UniTask<PlayerCommonEntity> GetCharacter(CharacterID id);          // 取得
     internal async UniTask DeletePlayer(CharacterID id);                              // 削除


### PR DESCRIPTION
Issue #143 の対応として、AdjustCommonCharacterEntityUsecaseにNPC生成対応と型安全性向上を実装しました。

## 変更内容

- CreateCharacterメソッドの型安全性向上（string → CharacterName）
- NPC用CreateCharacter(CharacterName, CharacterLevel)メソッド追加
- 既存テストの引数型対応とNPC生成テスト追加
- 関連ドキュメントの更新

## 受け入れ基準

- ✅ プレイヤー生成：CharacterName型で名前指定、レベル初期値で生成
- ✅ NPC生成：CharacterName型とCharacterLevel型で完全指定生成
- ✅ 既存のプレイヤー生成機能は動作変更なし（引数型のみ変更）
- ✅ 単体テスト追加：NPC生成の正常・異常系
- ✅ 単体テスト修正：既存テストの引数型対応
- ✅ 呼び出し元コード修正：string → CharacterNameの変換

Generated with [Claude Code](https://claude.ai/code)